### PR TITLE
Remove hard-coded smtp.ufl.edu

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2014-08-05 v0.9.1
+
+ * HOTFIX to replace smtp.ufl.edu with configurable option in setup.json
+
 2014-08-01 v0.9.0
 
  * Testing: Added Vagrant-based testing VM and documentation for how to use it

--- a/bin/redi.py
+++ b/bin/redi.py
@@ -36,6 +36,9 @@ sys.path.insert(0, proj_root+'bin/utils/')
 from redcap_transactions import redcap_transactions
 import redi_lib
 
+
+smtp_host_for_outbound_mail = None
+
 # INTERMEDIATE STEPS: XML!
 # step 1: parse raw XML to ElementTree: "data"
     # step 1b: call read-in function to load xml into ElementTree
@@ -75,6 +78,8 @@ def main():
     # read config
     setup_json = proj_root+'config/setup.json'
     setup = read_config(setup_json)
+    global smtp_host_for_outbound_mail
+    smtp_host_for_outbound_mail = setup['smtp_host_for_outbound_mail']
 
     # load custom post-processing rules
     rules = load_rules(setup, proj_root)
@@ -881,7 +886,7 @@ def send_report(sender,receiver,body):
     """
 
     try:
-       smtpObj = smtplib.SMTP('smtp.ufl.edu',25)
+       smtpObj = smtplib.SMTP(smtp_host_for_outbound_mail, 25)
        smtpObj.sendmail(sender, receiver, msg.as_string())
        print "Successfully sent email to: " + str(receiver)
     except Exception:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ INSTALL_REQUIRES = [
 
 setup(
     name='REDI',
-    version='0.9.0',
+    version='0.9.1',
     author='Christopher P Barnes, Philip Chase, Nicholas Rejack',
     author_email='cpb@ufl.edu, pbc@ufl.edu, nrejack@ufl.edu',
     packages=find_packages(exclude=['test']),


### PR DESCRIPTION
2014-08-05 v0.9.1
- HOTFIX to replace smtp.ufl.edu with configurable option in setup.json
