### PR TITLE
Add a 5 second sleep time to avoid rush conditions

### DIFF
--- a/bin/redi_lib.py
+++ b/bin/redi_lib.py
@@ -351,6 +351,7 @@ def create_empty_md5_database(db_path) :
         fresh_file = open(db_path, 'w')
         fresh_file.close()
         os.chmod(db_path, stat.S_IRUSR | stat.S_IWUSR)
+        time.sleep(5)
 
     except IOError as e:
         logger.error("I/O error: " + e.strerror + ' for file: ' + db_path)
@@ -384,7 +385,7 @@ def create_empty_table(db_path) :
     finally:
         if db:
             db.close()
-    logger.info('success reate_empty_table')
+    logger.info('success create_empty_table')
     return True
 
 


### PR DESCRIPTION
Add a 5 second sleep time to avoid rush conditions
when we create the `redi.db` SQLite file for the first time
and the table schema is not committed to the filesystem
