### PR TITLE
Closes #42 - "redcap_records.py lost the events and fields arguments"

### DIFF
--- a/bin/utils/redcap_records.py
+++ b/bin/utils/redcap_records.py
@@ -63,6 +63,17 @@ def main():
         dest='forms',
         default='',
         help='Specify a list of forms, separated by spaces, for which data should be returned.')
+    parser.add_argument(
+        '--fields',
+        dest='fields',
+        default='',
+        help='Specify a list of fields, separated by spaces, for which data should be returned.')
+    parser.add_argument(
+        '-e',
+        '--events',
+        dest='events',
+        default='',
+        help='Specify a list of events, separated by spaces, for which data should be returned.')
 
     # prepare the arguments we were given
     args = vars(parser.parse_args())
@@ -84,8 +95,12 @@ def main():
     # either we export data...
     if args['import_data'] == '':
         my_forms = args['forms'].split()
+        my_fields = args['fields'].split()
+        my_events = args['events'].split()
         data = project.export_records(
             forms=my_forms,
+            fields=my_fields,
+            events=my_events,
             format='csv',
             event_name='unique')
         print str(data)


### PR DESCRIPTION
Tested using
../bin/utils/redcap_records.py --token=121212 --url=http://localhost:8998/redcap/api/ -f "demographics" --events 1_arm_1
