### PR TITLE
Use boolean args `keep` and `emrdata`

### DIFF
--- a/bin/redi.py
+++ b/bin/redi.py
@@ -56,8 +56,6 @@ import redi_lib
 
 
 # Command line default argument values
-default_do_keep_gen_files = None
-
 _person_form_events_service = None
 
 translational_table_tree = None
@@ -108,8 +106,8 @@ def main():
     configuration_directory = args['configuration_directory_path']
     if configuration_directory is None:
         configuration_directory = os.path.join(data_directory, "config")
-    do_keep_gen_files = False if args['keep'] is None else True
-    get_emr_data = False if args['emrdata'] is None else True
+    do_keep_gen_files = args['keep']
+    get_emr_data = args['emrdata']
     dry_run = args['dryrun']
 
     #configure logger
@@ -535,16 +533,18 @@ def parse_args(arguments=None):
     # read the optional argument `-k` for keeping the generated files
     parser.add_argument(
         '-k', '--keep',
-        default=default_do_keep_gen_files,
+        default=False,
+        action='store_true',
         required=False,
-        help='Specify `yes` to preserve the files generated during execution')
+        help='Provide this argument to preserve the files generated during execution')
 
     # read the optional argument `-e` for getting EMR data
     parser.add_argument(
         '-e', '--emrdata',
-        default=None,
+        default=False,
+        action='store_true',
         required=False,
-        help='Specify `yes` to get EMR data')
+        help='Provide this argument to retrieve EMR data from the source server via sftp')
 
     # read the optional argument `-d` for running redi.py in dry run state
     parser.add_argument(

--- a/test/TestArgs.py
+++ b/test/TestArgs.py
@@ -1,0 +1,42 @@
+import unittest
+import redi
+
+class TestArgs(unittest.TestCase):
+    """ Verify that the command line arguments are parsed properly"""
+
+    def test_parse_args(self):
+        """Check boolean arguments parsing"""
+
+        # Verify that not passing `resume` sets it to false
+        args = redi.parse_args('--verbose --dryrun'.split())
+        self.assertTrue(args['verbose'])
+        self.assertTrue(args['dryrun'])
+        self.assertFalse(args['resume'])
+        self.assertFalse(args['keep'])
+        self.assertFalse(args['emrdata'])
+
+        # Verify that order does not matter
+        args = redi.parse_args('--resume --verbose --dryrun'.split())
+        self.assertTrue(args['resume'])
+        self.assertTrue(args['verbose'])
+        self.assertTrue(args['dryrun'])
+        self.assertFalse(args['keep'])
+        self.assertFalse(args['emrdata'])
+
+        args = redi.parse_args('--verbose --resume --dryrun'.split())
+        self.assertTrue(args['verbose'])
+        self.assertTrue(args['resume'])
+        self.assertTrue(args['dryrun'])
+        self.assertFalse(args['keep'])
+        self.assertFalse(args['emrdata'])
+
+        # Verify that `keep` and `emrdata` args are read properly
+        args = redi.parse_args('--verbose -e -k'.split())
+        self.assertTrue(args['verbose'])
+        self.assertTrue(args['emrdata'])
+        self.assertTrue(args['keep'])
+        self.assertFalse(args['resume'])
+        self.assertFalse(args['dryrun'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/TestResume.py
+++ b/test/TestResume.py
@@ -6,16 +6,6 @@ import unittest
 
 class TestResume(unittest.TestCase):
 
-    def test_resume_switch(self):
-        import bin.redi
-        redi = reload(bin.redi)
-
-        args = redi.parse_args('--verbose --dryrun'.split())
-        self.assertFalse(args['resume'])
-
-        args = redi.parse_args('--resume --verbose --dryrun'.split())
-        self.assertTrue(args['resume'])
-
     def test_no_resume_deletes_old_run_data(self):
         class MockPersonFormEvents(object):
             def delete(self):

--- a/test/TestSuite.py
+++ b/test/TestSuite.py
@@ -12,6 +12,7 @@ This file creates a test suite for all the test classes.
 '''
 import unittest
 from TestReadConfig import TestReadConfig
+from TestArgs import TestArgs
 from TestWriteToFile import TestWriteToFile
 from TestUpdateRedcapForm import TestUpdateRedcapForm
 from TestUpdateTimestamp import TestUpdateTimestamp
@@ -51,6 +52,7 @@ class redi_suite(unittest.TestSuite):
 
         # add the test to the suite in the order to be tested
         redi_test_suite.addTest(TestReadConfig)
+        redi_test_suite.addTest(TestArgs)
         redi_test_suite.addTest(TestWriteToFile)
         redi_test_suite.addTest(TestUpdateRedcapForm)
         redi_test_suite.addTest(TestUpdateTimestamp)


### PR DESCRIPTION
Closes issue #53 with dedicated unit test class `TestArgs`
