### PR TITLE
Feature/fix emr server params

### DIFF
--- a/bin/utils/SimpleConfigParser.py
+++ b/bin/utils/SimpleConfigParser.py
@@ -117,6 +117,7 @@ optional_parameters_dict = {
     "include_rule_errors_in_report": False,
     "redcap_support_sender_email": 'please-do-not-reply@example.com',
     "emr_sftp_server_port": 22,
+    "emr_sftp_server_password": None,
     "emr_sftp_server_private_key": None,
     "emr_sftp_server_private_key_pass": None,
 }


### PR DESCRIPTION
Remove password from required SFTP parameters. This allows the SSH key to work when no password is provded.
