### PR TITLE
Install mcrypt package for PHP to enable plugins

### DIFF
--- a/vagrant/bootstrap_functions.sh
+++ b/vagrant/bootstrap_functions.sh
@@ -21,6 +21,9 @@ function run_environment_updates() {
 
    # configure MySQL to start every time
    update-rc.d mysql defaults
+
+   # Install mcrypt package for PHP
+   apt-get install -y php5-mcrypt
 }
 
 function extract_redcap() {


### PR DESCRIPTION
This change installs mcrypt package for PHP, which enables plugins for our deployed REDCap.
