### PR TITLE
Fix multiple results same day

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ redi.db
 report.html
 redi.pstats
 callgraph.svg
+private/

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,10 @@ lint:
 
 clean:
 	find . -type f -name "*.pyc" -print | xargs rm -f
-	rm -rf out
-	rm -rf dist
-	rm -rf build
+	rm -rf out dist build
 	rm -rf *.egg-info
 	rm -rf nosetests.xml cover .coverage coverage.xml
+	rm -f unittest_pysftp_rsa_key unittest_pysftp_rsa_key.pub destination_file source_file
 	rm -rf *.egg
 	rm -f pylint.out
 	rm -f formData.xml

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -773,7 +773,7 @@ def compress_data_using_study_form_date(data):
     filt = dict()
 
     for subj in data_root.iter('subject'):
-        subj_name = subj.find('NAME').text
+        lab_name = subj.find('NAME').text
         study_id = subj.find('STUDY_ID').text
         form_name = subj.find('redcapFormName').text
         timestamp = subj.findtext("DATE_TIME_STAMP")
@@ -784,12 +784,12 @@ def compress_data_using_study_form_date(data):
 
         # extract the date portion "2015-01-01" from "2015-01-01 00:00:00"
         date = timestamp.split(" ")[0]
-        key = (subj_name, study_id, form_name, date)
-        key_long = (subj_name, study_id, form_name, timestamp)
+        key = (lab_name, study_id, form_name, date)
+        key_long = (lab_name, study_id, form_name, timestamp)
 
         if key in filt:
             logger.debug("Remove duplicate result for {} for the date: {} "\
-                "with key: {}".format(subj_name, date, key_long))
+                "with key: {}".format(lab_name, date, key_long))
             subj.getparent().remove(subj)
             continue
         else:

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -477,10 +477,10 @@ def _create_person_form_event_tree_with_data(
     write_element_tree_to_file(
         data,
         os.path.join(data_folder, 'rawDataWithDatumAndUnitsFieldNames.xml'))
-    # sort the data tree
-    sort_element_tree(data)
+    # sort the data tree and compress
+    sort_element_tree(data, data_folder)
     write_element_tree_to_file(data, os.path.join(data_folder, \
-        'rawDataSorted.xml'))
+        'rawDataSortedAfterCompression.xml'))
     # update eventName element
     alert_summary = update_event_name(data, form_events_tree, 'undefined')
     # write back the changed global Element Tree
@@ -731,7 +731,7 @@ def update_redcap_form(data, lookup_data, undefined):
         undefined)
 
 
-def sort_element_tree(data):
+def sort_element_tree(data, data_folder):
     """
     Sort element tree based on three given indices.
     @see #update_time_stamp()
@@ -743,7 +743,13 @@ def sort_element_tree(data):
     container = data.getroot()
     #batch.printxml(container)
     container[:] = sorted(container, key=getkey, reverse=False)
+
+    # print sorted data before compression for reference
+    write_element_tree_to_file(data, os.path.join(data_folder,
+        "rawDataSortedBeforeCompression.xml"))
+
     compress_data_using_study_form_date(data)
+
     #batch.printxml(container)
 
 

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -1851,6 +1851,9 @@ def verify_and_correct_collection_date(data, input_date_format):
         collection_date_summary_dict['total'] += 1
         collection_date_element = subject.find('DATE_TIME_STAMP')
         result_date_element = subject.find('RESULT_DATE')
+        # If DATE_TIME_STAMP tag is present but it has no text (ie blank tag)
+        # and if RESULT_DATE is present, then subtract 4 from RESULT_DATE and
+        # assign that value to DATE_TIME_STAMP
         if collection_date_element is not None and \
         result_date_element is not None:
             if not collection_date_element.text:
@@ -1861,6 +1864,11 @@ def verify_and_correct_collection_date(data, input_date_format):
                 timedelta(days=4)
                 collection_date_element.text = str(result_date_object)
                 collection_date_summary_dict['blank'] += 1
+            # else do nothing as DATE_TIME_STAMP does have a value
+
+        # else if DATE_TIME_STAMP tag is not present, create a new tag by the
+        # name DATE_TIME_STAMP and add this to the data ElementTree and assign
+        # to it the value RESULT_DATE - 4
         elif collection_date_element is None and \
         result_date_element is not None:
             new_collection_date_element = etree.Element('DATE_TIME_STAMP')

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -767,6 +767,7 @@ def compress_data_using_study_form_date(data):
     filt = dict()
 
     for subj in data_root.iter('subject'):
+        subj_name = subj.find('NAME').text
         study_id = subj.find('STUDY_ID').text
         form_name = subj.find('redcapFormName').text
         timestamp = subj.findtext("DATE_TIME_STAMP")
@@ -777,11 +778,12 @@ def compress_data_using_study_form_date(data):
 
         # extract the date portion "2015-01-01" from "2015-01-01 00:00:00"
         date = timestamp.split(" ")[0]
-        key = (study_id, form_name, date)
-        key_long = (study_id, form_name, timestamp)
+        key = (subj_name, study_id, form_name, date)
+        key_long = (subj_name, study_id, form_name, timestamp)
 
         if key in filt:
-            logger.debug("Remove duplicate result for the date: {} with key: {}".format(date, key_long))
+            logger.debug("Remove duplicate result for {} for the date: {} "\
+                "with key: {}".format(subj_name, date, key_long))
             subj.getparent().remove(subj)
             continue
         else:

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "PyCap >= 1.0",
         "pysftp >= 0.2.8",
         "docopt >= 0.6.2",
+        "pycrypto >= 2.6.1",
     ],
     entry_points={
         'console_scripts': [
@@ -47,7 +48,7 @@ setup(
     },
     test_suite='test.TestSuite',
     tests_require=[
-        "mock >= 1.0",
+        "mock >= 1.0.1",
         "sftpserver >= 0.2",
     ],
     setup_requires=[

--- a/test/TestCompressDataUsingStudyFormDate.py
+++ b/test/TestCompressDataUsingStudyFormDate.py
@@ -1,0 +1,60 @@
+import unittest
+from lxml import etree
+from redi import redi
+import logging
+
+
+class TestCompressDataUsingStudyFormDate(unittest.TestCase):
+
+    def setUp(self):
+         # silence logger during testing
+        redi.logger = logging.getLogger('redi')
+        redi.logger.addHandler(logging.NullHandler())
+
+        self.xml = """<?xml version="1.0" encoding="UTF-8"?>
+<study>
+    <subject>
+        <NAME>PLATELET COUNT</NAME>
+        <ORD_VALUE> KEEP ME PLEASE </ORD_VALUE>
+        <DATE_TIME_STAMP>2013-12-07 00:00:09</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
+    <subject>
+        <NAME>PLATELET COUNT</NAME>
+        <ORD_VALUE> discard 1 </ORD_VALUE>
+        <DATE_TIME_STAMP>2013-12-07 00:00:10</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
+    <subject>
+        <NAME>PLATELET COUNT</NAME>
+        <ORD_VALUE> discard 2 </ORD_VALUE>
+        <DATE_TIME_STAMP>2013-12-07 00:00:20</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
+</study>
+"""
+
+    def test_compress(self):
+        #parser = etree.XMLParser(remove_comments = True)
+        #data = etree.parse('ha.xml', parser = parser)
+        data = etree.ElementTree(etree.fromstring(self.xml))
+        redi.compress_data_using_study_form_date(data)
+        count = len(data.xpath('//subject'))
+        keep_ele = data.xpath('//subject/ORD_VALUE')[0]
+
+        # verify that only one subject element is left
+        self.assertTrue(count == 1)
+
+        # verify that we got the lab result with the earliest time on a given date
+        self.assertTrue("KEEP ME PLEASE", keep_ele.text)
+        #print etree.tostring(data, pretty_print = True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/TestCompressDataUsingStudyFormDate.py
+++ b/test/TestCompressDataUsingStudyFormDate.py
@@ -15,7 +15,7 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
 <study>
     <subject>
         <NAME>PLATELET COUNT</NAME>
-        <ORD_VALUE> KEEP ME PLEASE </ORD_VALUE>
+        <ORD_VALUE>KEEP ME PLEASE</ORD_VALUE>
         <DATE_TIME_STAMP>2013-12-07 00:00:09</DATE_TIME_STAMP>
         <STUDY_ID>999-0262</STUDY_ID>
         <timestamp>2013-12-07</timestamp>
@@ -23,7 +23,7 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
     </subject>
     <subject>
         <NAME>PLATELET COUNT</NAME>
-        <ORD_VALUE> discard 1 </ORD_VALUE>
+        <ORD_VALUE>discard 1</ORD_VALUE>
         <DATE_TIME_STAMP>2013-12-07 00:00:20</DATE_TIME_STAMP>
         <STUDY_ID>999-0262</STUDY_ID>
         <timestamp>2013-12-07</timestamp>
@@ -31,7 +31,7 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
     </subject>
     <subject>
         <NAME>PLATELET COUNT</NAME>
-        <ORD_VALUE> discard 2 </ORD_VALUE>
+        <ORD_VALUE>discard 2</ORD_VALUE>
         <DATE_TIME_STAMP>2013-12-07 00:00:30</DATE_TIME_STAMP>
         <STUDY_ID>999-0262</STUDY_ID>
         <timestamp>2013-12-07</timestamp>
@@ -39,7 +39,7 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
     </subject>
     <subject>
         <NAME>WHITE BLOOD COUNT</NAME>
-        <ORD_VALUE> KEEP ME TOO </ORD_VALUE>
+        <ORD_VALUE>KEEP ME TOO</ORD_VALUE>
         <DATE_TIME_STAMP>2013-12-07 00:00:10</DATE_TIME_STAMP>
         <STUDY_ID>999-0262</STUDY_ID>
         <timestamp>2013-12-07</timestamp>
@@ -47,7 +47,7 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
     </subject>
     <subject>
         <NAME>WHITE BLOOD COUNT</NAME>
-        <ORD_VALUE> discard 3 </ORD_VALUE>
+        <ORD_VALUE>discard 3</ORD_VALUE>
         <DATE_TIME_STAMP>2013-12-07 00:00:15</DATE_TIME_STAMP>
         <STUDY_ID>999-0262</STUDY_ID>
         <timestamp>2013-12-07</timestamp>
@@ -55,7 +55,7 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
     </subject>
     <subject>
         <NAME>WHITE BLOOD COUNT</NAME>
-        <ORD_VALUE> KEEP ME AS WELL </ORD_VALUE>
+        <ORD_VALUE>KEEP ME AS WELL</ORD_VALUE>
         <DATE_TIME_STAMP>2013-13-07 00:00:17</DATE_TIME_STAMP>
         <STUDY_ID>999-0262</STUDY_ID>
         <timestamp>2013-13-07</timestamp>
@@ -63,7 +63,7 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
     </subject>
     <subject>
         <NAME>GLUCOSE</NAME>
-        <ORD_VALUE> KEEP ME! </ORD_VALUE>
+        <ORD_VALUE>KEEP ME!</ORD_VALUE>
         <DATE_TIME_STAMP>2013-13-07 00:00:20</DATE_TIME_STAMP>
         <STUDY_ID>999-0262</STUDY_ID>
         <timestamp>2013-13-07</timestamp>
@@ -85,22 +85,22 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
 
         # verify that we got the lab result with the earliest time on a given
         # date
-        self.assertTrue("KEEP ME PLEASE", keep_ele.text)
+        self.assertEqual("KEEP ME PLEASE", keep_ele.text)
 
         # verify that a lab result with a different name on the same date and
         # in the same form is not deleted
         keep_ele = data.xpath('//subject/ORD_VALUE')[1]
-        self.assertTrue("KEEP ME TOO", keep_ele.text)
+        self.assertEqual("KEEP ME TOO", keep_ele.text)
 
         # verify that the lab result on a different date in the same form is
         # retained
         keep_ele = data.xpath('//subject/ORD_VALUE')[2]
-        self.assertTrue("KEEP ME AS WELL", keep_ele.text)
+        self.assertEqual("KEEP ME AS WELL", keep_ele.text)
 
         # verify that the lab result for a different form on the same day is
         # retianed
-        keep_ele = data.xpath('//subject/ORD_VALUE')[2]
-        self.assertTrue("KEEP ME!", keep_ele.text)
+        keep_ele = data.xpath('//subject/ORD_VALUE')[3]
+        self.assertEqual("KEEP ME!", keep_ele.text)
 
 
 if __name__ == "__main__":

--- a/test/TestCompressDataUsingStudyFormDate.py
+++ b/test/TestCompressDataUsingStudyFormDate.py
@@ -24,7 +24,7 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
     <subject>
         <NAME>PLATELET COUNT</NAME>
         <ORD_VALUE> discard 1 </ORD_VALUE>
-        <DATE_TIME_STAMP>2013-12-07 00:00:10</DATE_TIME_STAMP>
+        <DATE_TIME_STAMP>2013-12-07 00:00:20</DATE_TIME_STAMP>
         <STUDY_ID>999-0262</STUDY_ID>
         <timestamp>2013-12-07</timestamp>
         <redcapFormName>cbc</redcapFormName>
@@ -32,10 +32,42 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
     <subject>
         <NAME>PLATELET COUNT</NAME>
         <ORD_VALUE> discard 2 </ORD_VALUE>
-        <DATE_TIME_STAMP>2013-12-07 00:00:20</DATE_TIME_STAMP>
+        <DATE_TIME_STAMP>2013-12-07 00:00:30</DATE_TIME_STAMP>
         <STUDY_ID>999-0262</STUDY_ID>
         <timestamp>2013-12-07</timestamp>
         <redcapFormName>cbc</redcapFormName>
+    </subject>
+    <subject>
+        <NAME>WHITE BLOOD COUNT</NAME>
+        <ORD_VALUE> KEEP ME TOO </ORD_VALUE>
+        <DATE_TIME_STAMP>2013-12-07 00:00:10</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
+    <subject>
+        <NAME>WHITE BLOOD COUNT</NAME>
+        <ORD_VALUE> discard 3 </ORD_VALUE>
+        <DATE_TIME_STAMP>2013-12-07 00:00:15</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
+    <subject>
+        <NAME>WHITE BLOOD COUNT</NAME>
+        <ORD_VALUE> KEEP ME AS WELL </ORD_VALUE>
+        <DATE_TIME_STAMP>2013-13-07 00:00:17</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-13-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
+    <subject>
+        <NAME>GLUCOSE</NAME>
+        <ORD_VALUE> KEEP ME! </ORD_VALUE>
+        <DATE_TIME_STAMP>2013-13-07 00:00:20</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-13-07</timestamp>
+        <redcapFormName>chemistry</redcapFormName>
     </subject>
 </study>
 """
@@ -49,11 +81,26 @@ class TestCompressDataUsingStudyFormDate(unittest.TestCase):
         keep_ele = data.xpath('//subject/ORD_VALUE')[0]
 
         # verify that only one subject element is left
-        self.assertTrue(count == 1)
+        self.assertTrue(count == 4)
 
-        # verify that we got the lab result with the earliest time on a given date
+        # verify that we got the lab result with the earliest time on a given
+        # date
         self.assertTrue("KEEP ME PLEASE", keep_ele.text)
-        #print etree.tostring(data, pretty_print = True)
+
+        # verify that a lab result with a different name on the same date and
+        # in the same form is not deleted
+        keep_ele = data.xpath('//subject/ORD_VALUE')[1]
+        self.assertTrue("KEEP ME TOO", keep_ele.text)
+
+        # verify that the lab result on a different date in the same form is
+        # retained
+        keep_ele = data.xpath('//subject/ORD_VALUE')[2]
+        self.assertTrue("KEEP ME AS WELL", keep_ele.text)
+
+        # verify that the lab result for a different form on the same day is
+        # retianed
+        keep_ele = data.xpath('//subject/ORD_VALUE')[2]
+        self.assertTrue("KEEP ME!", keep_ele.text)
 
 
 if __name__ == "__main__":

--- a/test/TestSortElementTree.py
+++ b/test/TestSortElementTree.py
@@ -1,212 +1,74 @@
 import unittest
-import os
 from lxml import etree
 from redi import redi
-
-file_dir = os.path.dirname(os.path.realpath(__file__))
-goal_dir = os.path.join(file_dir, "../")
-proj_root = os.path.abspath(goal_dir)+'/'
-
 
 class TestSortElementTree(unittest.TestCase):
 
     def setUp(self):
-        # un-sorted XML file
-        self.unsorted = """
-        <study>
-        <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>06/09/19</Collection_Date>
-        <Collection_Time>13:50</Collection_Time>
-        <Component_Name>HEMATOCRIT</Component_Name>
-        <loinc_code>1534436</loinc_code>
-        <Reference_Unit>%</Reference_Unit>
-        <Result_Value>34.5</Result_Value>
-    <timestamp>1907-09-24 13:50</timestamp><redcapFormName>undefined</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>11/30/16</Collection_Date>
-        <Collection_Time>16:01</Collection_Time>
-        <Component_Name>BILIRUBIN DIRECT</Component_Name>
-        <loinc_code>1558221</loinc_code>
-        <Reference_Unit>mg/dL</Reference_Unit>
-        <Result_Value>0.9</Result_Value>
-    <timestamp>1903-03-31 16:01</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>06/09/19</Collection_Date>
-        <Collection_Time>13:50</Collection_Time>
-        <Component_Name>HEMOGLOBIN</Component_Name>
-        <loinc_code>1534435</loinc_code>
-        <Reference_Unit>g/dL</Reference_Unit>
-        <Result_Value>11.3</Result_Value>
-    <timestamp>1907-09-24 13:50</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>11/30/16</Collection_Date>
-        <Collection_Time>12:38</Collection_Time>
-        <Component_Name>BILIRUBIN DIRECT</Component_Name>
-        <loinc_code>1558221</loinc_code>
-        <Reference_Unit>mg/dL</Reference_Unit>
-        <Result_Value>0.8</Result_Value>
-    <timestamp>1903-03-31 12:38</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>12/12/16</Collection_Date>
-        <Collection_Time>11:00</Collection_Time>
-        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
-        <loinc_code>1577876</loinc_code>
-        <Reference_Unit>g/dL</Reference_Unit>
-        <Result_Value>8.7</Result_Value>
-    <timestamp>1907-09-10 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>11/30/16</Collection_Date>
-        <Collection_Time>16:01</Collection_Time>
-        <Component_Name>BILIRUBIN DIRECT</Component_Name>
-        <loinc_code>1558221</loinc_code>
-        <Reference_Unit>mg/dL</Reference_Unit>
-        <Result_Value>0.9</Result_Value>
-    <timestamp>1903-03-31 16:01</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>06/09/19</Collection_Date>
-        <Collection_Time>13:50</Collection_Time>
-        <Component_Name>HEMATOCRIT</Component_Name>
-        <loinc_code>1534436</loinc_code>
-        <Reference_Unit>%</Reference_Unit>
-        <Result_Value>34.5</Result_Value>
-    <timestamp>1907-09-24 13:50</timestamp><redcapFormName>undefined</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>06/09/19</Collection_Date>
-        <Collection_Time>13:50</Collection_Time>
-        <Component_Name>HEMOGLOBIN</Component_Name>
-        <loinc_code>1534435</loinc_code>
-        <Reference_Unit>g/dL</Reference_Unit>
-        <Result_Value>11.3</Result_Value>
-    <timestamp>1907-09-24 13:50</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>11/30/16</Collection_Date>
-        <Collection_Time>12:38</Collection_Time>
-        <Component_Name>BILIRUBIN DIRECT</Component_Name>
-        <loinc_code>1558221</loinc_code>
-        <Reference_Unit>mg/dL</Reference_Unit>
-        <Result_Value>0.8</Result_Value>
-    <timestamp>1903-03-31 12:38</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>12/12/16</Collection_Date>
-        <Collection_Time>11:00</Collection_Time>
-        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
-        <loinc_code>1577876</loinc_code>
-        <Reference_Unit>g/dL</Reference_Unit>
-        <Result_Value>8.7</Result_Value>
-    <timestamp>1907-09-10 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    </study>"""
+        #redi.configure_logging('.')
 
-        # above data manually sorted
-        self.sorted = """
+        # un-sorted XML file
+        self.unsorted = """<?xml version="1.0" encoding="UTF-8"?>
 <study>
-        <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>12/12/16</Collection_Date>
-        <Collection_Time>11:00</Collection_Time>
-        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
-        <loinc_code>1577876</loinc_code>
-        <Reference_Unit>g/dL</Reference_Unit>
-        <Result_Value>8.7</Result_Value>
-    <timestamp>1907-09-10 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+   <subject>
+        <NAME>PLATELET COUNT</NAME>
+        <DATE_TIME_STAMP>2013-12-02 00:00:00</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
+ 
     <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>06/09/19</Collection_Date>
-        <Collection_Time>13:50</Collection_Time>
-        <Component_Name>HEMOGLOBIN</Component_Name>
-        <loinc_code>1534435</loinc_code>
-        <Reference_Unit>g/dL</Reference_Unit>
-        <Result_Value>11.3</Result_Value>
-    <timestamp>1907-09-24 13:50</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+        <NAME>PLATELET COUNT</NAME>
+        <DATE_TIME_STAMP>2013-12-03 00:00:00</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
     <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>11/30/16</Collection_Date>
-        <Collection_Time>12:38</Collection_Time>
-        <Component_Name>BILIRUBIN DIRECT</Component_Name>
-        <loinc_code>1558221</loinc_code>
-        <Reference_Unit>mg/dL</Reference_Unit>
-        <Result_Value>0.8</Result_Value>
-    <timestamp>1903-03-31 12:38</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+        <NAME>PLATELET COUNT</NAME>
+        <DATE_TIME_STAMP>2013-12-01 00:00:00</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
+</study>"""
+
+        # we expect the following sorted tree
+        self.sorted_tree = """<?xml version="1.0" encoding="UTF-8"?>
+<study>
     <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>11/30/16</Collection_Date>
-        <Collection_Time>16:01</Collection_Time>
-        <Component_Name>BILIRUBIN DIRECT</Component_Name>
-        <loinc_code>1558221</loinc_code>
-        <Reference_Unit>mg/dL</Reference_Unit>
-        <Result_Value>0.9</Result_Value>
-    <timestamp>1903-03-31 16:01</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+        <NAME>PLATELET COUNT</NAME>
+        <DATE_TIME_STAMP>2013-12-01 00:00:00</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
     <subject>
-        <STUDY_ID>11</STUDY_ID>
-        <Collection_Date>06/09/19</Collection_Date>
-        <Collection_Time>13:50</Collection_Time>
-        <Component_Name>HEMATOCRIT</Component_Name>
-        <loinc_code>1534436</loinc_code>
-        <Reference_Unit>%</Reference_Unit>
-        <Result_Value>34.5</Result_Value>
-    <timestamp>1907-09-24 13:50</timestamp><redcapFormName>undefined</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+        <NAME>PLATELET COUNT</NAME>
+        <DATE_TIME_STAMP>2013-12-02 00:00:00</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
     <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>12/12/16</Collection_Date>
-        <Collection_Time>11:00</Collection_Time>
-        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
-        <loinc_code>1577876</loinc_code>
-        <Reference_Unit>g/dL</Reference_Unit>
-        <Result_Value>8.7</Result_Value>
-    <timestamp>1907-09-10 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>06/09/19</Collection_Date>
-        <Collection_Time>13:50</Collection_Time>
-        <Component_Name>HEMOGLOBIN</Component_Name>
-        <loinc_code>1534435</loinc_code>
-        <Reference_Unit>g/dL</Reference_Unit>
-        <Result_Value>11.3</Result_Value>
-    <timestamp>1907-09-24 13:50</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>11/30/16</Collection_Date>
-        <Collection_Time>12:38</Collection_Time>
-        <Component_Name>BILIRUBIN DIRECT</Component_Name>
-        <loinc_code>1558221</loinc_code>
-        <Reference_Unit>mg/dL</Reference_Unit>
-        <Result_Value>0.8</Result_Value>
-    <timestamp>1903-03-31 12:38</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>11/30/16</Collection_Date>
-        <Collection_Time>16:01</Collection_Time>
-        <Component_Name>BILIRUBIN DIRECT</Component_Name>
-        <loinc_code>1558221</loinc_code>
-        <Reference_Unit>mg/dL</Reference_Unit>
-        <Result_Value>0.9</Result_Value>
-    <timestamp>1903-03-31 16:01</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    <subject>
-        <STUDY_ID>22</STUDY_ID>
-        <Collection_Date>06/09/19</Collection_Date>
-        <Collection_Time>13:50</Collection_Time>
-        <Component_Name>HEMATOCRIT</Component_Name>
-        <loinc_code>1534436</loinc_code>
-        <Reference_Unit>%</Reference_Unit>
-        <Result_Value>34.5</Result_Value>
-    <timestamp>1907-09-24 13:50</timestamp><redcapFormName>undefined</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
-    </study>"""
+        <NAME>PLATELET COUNT</NAME>
+        <DATE_TIME_STAMP>2013-12-03 00:00:00</DATE_TIME_STAMP>
+        <STUDY_ID>999-0262</STUDY_ID>
+        <timestamp>2013-12-07</timestamp>
+        <redcapFormName>cbc</redcapFormName>
+    </subject>
+</study>"""
+
 
     def test_sort_elementtree(self):
-        self.data = etree.ElementTree(etree.fromstring(self.unsorted))
-        redi.sort_element_tree(self.data)
-        result = etree.tostring(self.data)
-        self.expect = etree.tostring(etree.fromstring(self.sorted))
-        self.assertEqual(self.expect, result)
+        tree_to_sort = etree.ElementTree(etree.fromstring(self.unsorted))
+        redi.sort_element_tree(tree_to_sort)
+
+        par = etree.XMLParser(remove_blank_text = True)
+        clean_expect = etree.XML(self.sorted_tree, parser=par)
+        clean_result = etree.XML(etree.tostring(tree_to_sort), parser=par)
+        self.assertEqual(etree.tostring(clean_expect), etree.tostring(clean_result))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/TestSortElementTree.py
+++ b/test/TestSortElementTree.py
@@ -1,4 +1,6 @@
 import unittest
+import tempfile
+import os
 from lxml import etree
 from redi import redi
 
@@ -60,15 +62,31 @@ class TestSortElementTree(unittest.TestCase):
     </subject>
 </study>"""
 
+        self.dirpath = tempfile.mkdtemp()
+
 
     def test_sort_elementtree(self):
         tree_to_sort = etree.ElementTree(etree.fromstring(self.unsorted))
-        redi.sort_element_tree(tree_to_sort)
+        redi.sort_element_tree(tree_to_sort, self.dirpath)
 
         par = etree.XMLParser(remove_blank_text = True)
         clean_expect = etree.XML(self.sorted_tree, parser=par)
         clean_result = etree.XML(etree.tostring(tree_to_sort), parser=par)
         self.assertEqual(etree.tostring(clean_expect), etree.tostring(clean_result))
+
+    def tearDown(self):
+        try:
+            os.unlink(os.path.join(self.dirpath,
+                "rawDataSortedBeforeCompression.xml"))
+        except:
+            print("setUp failed to unlink "\
+                "file \'rawDataSortedBeforeCompression\'.xml")
+        try:
+            os.rmdir(self.dirpath)
+        except OSError:
+            raise LogException("Folder \'{}\' is not empty, hence cannot "\
+                "be deleted.".format(self.dirpath))
+        return()
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/TestSuite.py
+++ b/test/TestSuite.py
@@ -18,6 +18,8 @@ from TestUpdateTimestamp import TestUpdateTimestamp
 from TestUpdateFormDateField import TestUpdateFormDateField
 from TestUpdateFormCompletedFieldName import TestUpdateFormCompletedFieldName
 from TestSortElementTree import TestSortElementTree
+from TestCompressDataUsingStudyFormDate import TestCompressDataUsingStudyFormDate
+
 from TestUpdateDataFromLookup import TestUpdateDataFromLookup
 from TestAddElementsToTree import TestAddElementsToTree
 from TestUpdateRedcapFieldNameValueAndUnits import TestUpdateRedcapFieldNameValueAndUnits
@@ -58,6 +60,7 @@ class redi_suite(unittest.TestSuite):
         redi_test_suite.addTest(TestUpdateTimestamp)
         redi_test_suite.addTest(TestUpdateFormDateField)
         redi_test_suite.addTest(TestSortElementTree)
+        redi_test_suite.addTest(TestCompressDataUsingStudyFormDate)
         redi_test_suite.addTest(TestUpdateDataFromLookup)
         redi_test_suite.addTest(TestAddElementsToTree)
         redi_test_suite.addTest(TestUpdateRedcapFieldNameValueAndUnits)


### PR DESCRIPTION
- Inside the sort function, instead of using the timestamp key (which is actually just the date), we used DATE_TIME_STAMP along with STDUY_ID and form name

- After sorting, compress_data_using_study_form_date function removes all elements with duplicate dates (so that only the element with the earliest time on that date is retained)

- Added new unit test for compress_data_using_study_form_date and fixed the outdated test for sorting