### PR TITLE
Improve preproc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RED-I Project
 =============
 
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.10014.png ".")](http://dx.doi.org/10.5281/zenodo.10014)
+<a href="http://dx.doi.org/10.5281/zenodo.17125"><img src="https://zenodo.org/badge/4064/ctsit/redi.svg"><a>
 [![Travis CI](https://api.travis-ci.org/ctsit/redi.svg?branch=master)](https://api.travis-ci.org/ctsit/redi.svg?branch=master)
 [![Version](https://pypip.in/v/redi/badge.png)](https://pypip.in/v/redi/badge.png)
 [![Coverage Status Master](https://coveralls.io/repos/ctsit/redi/badge.svg?branch=master)](https://coveralls.io/r/ctsit/redi?branch=master)

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -309,6 +309,23 @@ def _run(config_file, configuration_directory, do_keep_gen_files, dry_run,
     # load custom post-processing rules
     rules = load_rules(settings.rules, configuration_directory)
 
+    errors = run_preproc(pre_filters, settings)
+    map(logger.warning, errors)
+
+    raw_txt_file = os.path.join(configuration_directory, 'raw.txt')
+    escaped_file = os.path.join(configuration_directory, 'rawEscaped.txt')
+    raw_xml_file = os.path.join(configuration_directory, 'raw.xml')
+
+    # replace certain characters with escape sequences
+    GetEmrData.data_preprocessing(raw_txt_file, escaped_file)
+
+    # run csv2xml.py to generate data in xml format
+    GetEmrData.generate_xml(escaped_file, raw_xml_file)
+
+    # delete rawEscaped.txt
+    GetEmrData.cleanup(escaped_file)
+
+
     raw_xml_file = os.path.join(configuration_directory, settings.raw_xml_file)
     email_settings = get_email_settings(settings)
     db_path = database_path
@@ -326,8 +343,6 @@ def _run(config_file, configuration_directory, do_keep_gen_files, dry_run,
     if not resume:
         _delete_last_runs_data(data_folder)
 
-        errors = run_preproc(pre_filters, settings)
-        map(logger.warning, errors)
         # TODO: Add preproc errors to report
 
         alert_summary, person_form_event_tree_with_data, rule_errors, \

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -47,7 +47,7 @@ Options:
 """
 
 __author__ = "University of Florida CTS-IT Team"
-__version__ = "0.14.2"
+__version__ = "0.14.1"
 __email__ = "ctsit@ctsi.ufl.edu"
 __status__ = "Development"
 

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -47,7 +47,7 @@ Options:
 """
 
 __author__ = "University of Florida CTS-IT Team"
-__version__ = "0.13.2"
+__version__ = "0.14.2"
 __email__ = "ctsit@ctsi.ufl.edu"
 __status__ = "Development"
 
@@ -316,14 +316,16 @@ def _run(config_file, configuration_directory, do_keep_gen_files, dry_run,
     escaped_file = os.path.join(configuration_directory, 'rawEscaped.txt')
     raw_xml_file = os.path.join(configuration_directory, 'raw.xml')
 
+    # TODO: make this able to run against a local file if desired
     # replace certain characters with escape sequences
-    GetEmrData.data_preprocessing(raw_txt_file, escaped_file)
-
-    # run csv2xml.py to generate data in xml format
-    GetEmrData.generate_xml(escaped_file, raw_xml_file)
-
-    # delete rawEscaped.txt
-    GetEmrData.cleanup(escaped_file)
+    if get_emr_data:
+        GetEmrData.data_preprocessing(raw_txt_file, escaped_file)
+    if get_emr_data:
+        # run csv2xml.py to generate data in xml format
+        GetEmrData.generate_xml(escaped_file, raw_xml_file)
+    if get_emr_data:
+        # delete rawEscaped.txt
+        GetEmrData.cleanup(escaped_file)
 
 
     raw_xml_file = os.path.join(configuration_directory, settings.raw_xml_file)

--- a/redi/utils/GetEmrData.py
+++ b/redi/utils/GetEmrData.py
@@ -162,18 +162,6 @@ def get_emr_data(conf_dir, connection_details):
     :connection_details EmrFileAccessDetails object
     """
     raw_txt_file = os.path.join(conf_dir, 'raw.txt')
-    escaped_file = os.path.join(conf_dir, 'rawEscaped.txt')
-    raw_xml_file = os.path.join(conf_dir, 'raw.xml')
 
     # download csv file
     download_file(raw_txt_file, connection_details)
-
-    # replace certain characters with escape sequences
-    data_preprocessing(raw_txt_file, escaped_file)
-
-    # run csv2xml.py to generate data in xml format
-    generate_xml(escaped_file, raw_xml_file)
-
-    # delete rawEscaped.txt
-    cleanup(escaped_file)
-

--- a/test/TestCreateImportDataJson.py
+++ b/test/TestCreateImportDataJson.py
@@ -16,7 +16,7 @@
 # For full text of the BSD 3-Clause License see http://opensource.org/licenses/BSD-3-Clause
 
 """
-TestCreateEavOutput.py:
+TestCreateImportDataJson.py:
 
    Verifies the correct functionality 
    of the `test_create_import_data_json` function

--- a/test/TestGetDBPath.py
+++ b/test/TestGetDBPath.py
@@ -35,5 +35,13 @@ class TestGetDBPath(unittest.TestCase):
         assert os.path.exists(full_db_path) == 1
         shutil.rmtree(full_db_path)
 
+    def test_get_db_path_not_exists(self):
+        # verify that db path is created if it doesn't exist
+        db_path =  "nonExistentPath"
+        batch_info_database = "database.db"
+        created_db_path = redi.get_db_path(batch_info_database, db_path)
+        assert created_db_path ==  os.path.join(db_path, batch_info_database)
+        shutil.rmtree(db_path)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/TestGetDBPath.py
+++ b/test/TestGetDBPath.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# Contributors:
+# Christopher P. Barnes <senrabc@gmail.com>
+# Andrei Sura: github.com/indera
+# Mohan Das Katragadda <mohan.das142@gmail.com>
+# Philip Chase <philipbchase@gmail.com>
+# Ruchi Vivek Desai <ruchivdesai@gmail.com>
+# Taeber Rapczak <taeber@ufl.edu>
+# Nicholas Rejack <nrejack@ufl.edu>
+# Josh Hanna <josh@hanna.io>
+# Copyright (c) 2014-2015, University of Florida
+# All rights reserved.
+#
+# Distributed under the BSD 3-Clause License
+# For full text of the BSD 3-Clause License see http://opensource.org/licenses/BSD-3-Clause
+
+import unittest
+import os
+import tempfile
+from redi import redi
+import shutil
+
+
+class TestGetDBPath(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_get_db_path(self):
+        db_path = tempfile.mkdtemp()
+        batch_info_database = "database.db"
+        redi.get_db_path(batch_info_database, db_path)
+        full_db_path = os.path.join(batch_info_database, db_path)
+        assert os.path.exists(full_db_path) == 1
+        shutil.rmtree(full_db_path)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/TestGetEMRData.py
+++ b/test/TestGetEMRData.py
@@ -51,6 +51,7 @@ class TestGetEMRData(unittest.TestCase):
         Note: This test is not concerned with testing the sftp communication"""
         temp_folder = tempfile.mkdtemp('/')
         temp_txt_file = os.path.join(temp_folder, "raw.txt")
+        temp_escaped_file = os.path.join(temp_folder, "rawEscaped.txt")
         temp_xml_file = os.path.join(temp_folder, "raw.xml")
 
         input_string = '''"NAME","COMPONENT_ID","RESULT","REFERENCE_UNIT","DATE_TIME_STAMP","STUDY_ID"
@@ -72,6 +73,8 @@ class TestGetEMRData(unittest.TestCase):
             )
 
         GetEmrData.get_emr_data(temp_folder, props)
+        GetEmrData.data_preprocessing(temp_txt_file, temp_escaped_file)
+        GetEmrData.generate_xml(temp_escaped_file, temp_xml_file)
 
         with open(temp_xml_file) as f:
             result = f.read()

--- a/test/TestSuite.py
+++ b/test/TestSuite.py
@@ -63,6 +63,7 @@ from TestVerifyAndCorrectCollectionDate import TestVerifyAndCorrectCollectionDat
 from TestRediEmail import TestRediEmail
 from TestSentEventIndex import TestSentEventIndex
 from TestSendDatatoRedcap import TestSendDatatoRedcap
+from TestGetDBPath import TestGetDBPath
 
 class redi_suite(unittest.TestSuite):
 
@@ -108,6 +109,8 @@ class redi_suite(unittest.TestSuite):
         redi_test_suite.addTest(TestRediEmail)
         redi_test_suite.addTest(TestDaysSinceToday)
         redi_test_suite.addTest(TestSendDatatoRedcap)
+
+        redi_test_suite.addTest(TestGetDBPath)
 
         # return the suite
         return unittest.TestSuite([redi_test_suite])


### PR DESCRIPTION
Improve the preprocessing by running the CSV to XML conversion against the newly generated raw.txt file. This relocates CSV to XML preprocessing calls from GetEmrData and simplifies the get_emr_data function, which now only connects to download the file.