### PR TITLE
Move redcap_records.py to its own package, redcap_cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RED-I Project
 Introduction
 ------------
 
-The REDCap Electronic Data Importer (RED-I) is a tool which is used to
+The Research Electronic Data Importer (RED-I) is a tool which is used to
 automate the process of loading clinical data from Electronic Medical
 Records (EMR) systems into [REDCap](http://www.project-redcap.org/)
 Study data capture systems. RED-I is a general purpose tool for REDCap

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RED-I Project
 Introduction
 ------------
 
-The Research Electronic Data Importer (RED-I) is a tool which is used to
+The REDCap Electronic Data Importer (RED-I) is a tool which is used to
 automate the process of loading clinical data from Electronic Medical
 Records (EMR) systems into [REDCap](http://www.project-redcap.org/)
 Study data capture systems. RED-I is a general purpose tool for REDCap

--- a/docs/api/redi.utils.rst
+++ b/docs/api/redi.utils.rst
@@ -44,14 +44,6 @@ redi.utils.redcapClient module
     :undoc-members:
     :show-inheritance:
 
-redi.utils.redcap_records module
---------------------------------
-
-.. automodule:: redi.utils.redcap_records
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 redi.utils.redi_email module
 ----------------------------
 

--- a/docs/integration_testing.rst
+++ b/docs/integration_testing.rst
@@ -86,7 +86,7 @@ Erase the data in the correct project if necessary:
 ::
 
       $ cd ../vagrant && vagrant ssh -c 'cd /vagrant/scripts && php redcapdbm.php -d 12'
-      
+
        Deleting data for project: 12, name: hcvtarget_20_development
        Rows deleted from `redcap_surveys_response`:0
        Rows deleted from `redcap_surveys_participants`:0
@@ -97,7 +97,7 @@ Erase the data in the correct project if necessary:
 
    ::
 
-        $ ../redi/utils/redcap_records.py --token=121212 --url=http://localhost:8998/redcap/api/ -i demographic_test_data.csv
+        $ redcap_records --token=121212 --url=http://localhost:8998/redcap/api/ -i demographic_test_data.csv
 
 On success the following text is returned:
 
@@ -149,7 +149,7 @@ If the token is invalid the following error is returned:
 
    ::
 
-        $ ../redi/utils/redcap_records.py --token=121212 --url=http://localhost:8998/redcap/api/ -f "demgraphics chemistry" > output_B.csv
+        $ redcap_records --token=121212 --url=http://localhost:8998/redcap/api/ -f "demgraphics chemistry" > output_B.csv
 
 If you have a lot of forms, the output comparison is easier if you
 export the forms separately like this:
@@ -157,16 +157,16 @@ export the forms separately like this:
 ::
 
         #!/bin/bash
-        
+
         batch=$1
         forms="demographics chemistry cbc inr hcv_rna_results"
         if [ ! -e $batch ]; then
             mkdir $batch
         fi
-        
+
         for form in $forms
             do
-              ../redi/utils/redcap_records.py --token=121212 --url=http://localhost:8998/redcap/api/ --forms=$form > $batch/$form.csv
+              redcap_records --token=121212 --url=http://localhost:8998/redcap/api/ --forms=$form > $batch/$form.csv
             done
 
 Later do the diff like this:
@@ -210,7 +210,7 @@ Later do the diff like this:
 
    ::
 
-       $ diff -u output_A.csv output_B.csv 
+       $ diff -u output_A.csv output_B.csv
 
 If no new behavior was introduced the output from the command above
 should be an empty string.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lxml >= 3.3.5
 PyCap >= 1.0
 pysftp >= 0.2.8
 docopt >= 0.6.2
+redcap_cli >= 0.1.0

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "pysftp >= 0.2.8",
         "docopt >= 0.6.2",
         "pycrypto >= 2.6.1",
+        "redcap_cli >= 0.1.0",
     ],
     entry_points={
         'console_scripts': [

--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -21,7 +21,8 @@ ifneq ("$(wildcard $(MAKE_CONFIG_FILE))", "")
    REDCAP_API_URI := $(shell cat ${CONFIG_FILE} | sed -e 's/ //g' | grep -v '^\#' | grep 'redcap_uri=' | cut -d '=' -f2)
    REDCAP_VM_URI := $(subst api/,,$(REDCAP_API_URI))
    REDCAP_VM_TOKEN := $(shell cat ${CONFIG_FILE} | sed -e 's/ //g' | grep -v '^\#' | grep 'token=' | cut -d '=' -f2)
-   REDCAP_RECORDS_CMD:=../redi/utils/redcap_records.py --token=$(REDCAP_VM_TOKEN) --url=$(REDCAP_API_URI)
+   REDCAP_RECORDS_PROGRAM:=redcap_records
+   REDCAP_RECORDS_CMD:=$REDCAP_RECORDS_PROGRAM --token=$(REDCAP_VM_TOKEN) --url=$(REDCAP_API_URI)
    REDCAP_PROJECT_ID := $(shell cat ${MAKE_CONFIG_FILE} | sed -e 's/ //g' | grep -v '^\#' | grep 'redcap_project_id=' | cut -d '=' -f2)
    REDCAP_PROJECT_FORMS := $(shell cat ${MAKE_CONFIG_FILE} | sed -e 's/ //g' | grep -v '^\#' | grep 'redcap_project_forms=' | cut -d '=' -f2)
    REDCAP_PROJECT_ENROLLMENT_FORM := $(shell cat ${MAKE_CONFIG_FILE} | sed -e 's/ //g' | grep -v '^\#' | grep 'redcap_project_enrollment_form=' | cut -d '=' -f2)
@@ -101,6 +102,7 @@ check_config:
 	@test -f $(REDCAP_CODE_ZIP_FILE) || (echo 'Please obtain the redcap software zip file "$(REDCAP_CODE_ZIP_FILE)"' && exit 1)
 	@test -d $(REDCAP_CODE_PLUGIN_FOLDER) || (echo 'WARNING: did not find a REDCap plugins folder "$(REDCAP_CODE_PLUGIN_FOLDER)"')
 	@test -f $(ENROLLMENT_CSV_FILE) || (echo 'Config error: missing file "$(ENROLLMENT_CSV_FILE)"' && exit 1)
+	@which $REDCAP_RECORDS_PROGRAM || (echo 'Config error: missing redcap_records command.  Run "pip install redcap_cli" to install' && exit 1)
 
 show_config: check_config
 	@echo "$(MAKE_CONFIG_FILE) indicates that extra parameters should be read from : $(CONFIG_FILE)"


### PR DESCRIPTION
This pull request removes redcap_records.py from redi and replaces all references to it with references to the binary form the installed redcap_cli package.  redcap_cli is already published in the Python Package Index at https://pypi.python.org/pypi/redcap_cli/0.1.0. 
