### PR TITLE
Add multiple file fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RED-I Project
 Introduction
 ------------
 
-The REDCap Electronic Data Importer (RED-I) is a tool which is used to
+The Research Electronic Data Importer (RED-I) is a tool which is used to
 automate the process of loading clinical data from Electronic Medical
 Records (EMR) systems into [REDCap](http://www.project-redcap.org/)
 Study data capture systems. RED-I is a general purpose tool for REDCap

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RED-I Project
 Introduction
 ------------
 
-The Research Electronic Data Importer (RED-I) is a tool which is used to
+The REDCap Electronic Data Importer (RED-I) is a tool which is used to
 automate the process of loading clinical data from Electronic Medical
 Records (EMR) systems into [REDCap](http://www.project-redcap.org/)
 Study data capture systems. RED-I is a general purpose tool for REDCap

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -295,7 +295,8 @@ def _run(config_file, configuration_directory, do_keep_gen_files, dry_run,
     # Getting EMR data
     if get_emr_data:
         connection_details = EmrFileAccessDetails(
-            os.path.join(settings.emr_sftp_project_name, settings.emr_data_file),
+            settings.emr_sftp_project_name,
+            settings.emr_data_file,
             settings.emr_sftp_server_hostname,
             settings.emr_sftp_server_username,
             settings.emr_sftp_server_password,

--- a/redi/utils/GetEmrData.py
+++ b/redi/utils/GetEmrData.py
@@ -26,6 +26,8 @@ import pysftp
 from csv2xml import openio, Writer
 from paramiko.ssh_exception import SSHException, BadAuthenticationType
 import sys
+import ast
+import copy
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -37,6 +39,7 @@ class EmrFileAccessDetails(object) :
     @see redi#_run()
     """
     def __init__(self,
+            emr_sftp_project_name,
             emr_download_file,
             emr_host,
             emr_username,
@@ -46,6 +49,7 @@ class EmrFileAccessDetails(object) :
             emr_private_key_pass
             ):
 
+        self.sftp_project_name = emr_sftp_project_name
         self.download_file = emr_download_file
         self.host = emr_host
         self.username = emr_username
@@ -67,8 +71,9 @@ def download_file(destination, access_details):
     @see get_emr_data()
     """
     connection_info = dict(access_details.__dict__)
-    # delete unnecessary element form the dictionary
+    # delete unnecessary elements form the dictionary
     del connection_info['download_file']
+    del connection_info['sftp_project_name']
 
     # check for errors during authentication with EMR server
     try:
@@ -161,7 +166,24 @@ def get_emr_data(conf_dir, connection_details):
     :conf_dir configuration directory name
     :connection_details EmrFileAccessDetails object
     """
-    raw_txt_file = os.path.join(conf_dir, 'raw.txt')
-
-    # download csv file
-    download_file(raw_txt_file, connection_details)
+    # enable backwards comparability with older config repos
+    # try reading emr_data_file as a dict first
+    try:
+        connection_details.download_file = ast.literal_eval(connection_details.download_file)
+        logger.info("Downloading multiple files: %s", str(connection_details.download_file))
+        for key in connection_details.download_file:
+            # make a copy of the dict
+            temp_connection_details = copy.deepcopy(connection_details)
+            # download the next file in the dict
+            raw_txt_file = os.path.join(conf_dir, connection_details.download_file[key])
+            temp_connection_details.download_file = os.path.join(connection_details.sftp_project_name, key)
+            logger.info("Downloading remote file file: " + temp_connection_details.download_file)
+            logger.info("Saving to local file name: " + raw_txt_file)
+            download_file(raw_txt_file, temp_connection_details)
+    # if we can't read it into a dictionary, assume it's a single file
+    except ValueError:
+        connection_details.download_file = os.path.join(connection_details.sftp_project_name, connection_details.download_file)
+        logger.info("Downloading single file: %s", connection_details.download_file)
+        raw_txt_file = os.path.join(conf_dir, 'raw.txt')
+        # download csv file
+        download_file(raw_txt_file, connection_details)

--- a/test/TestGetEMRData.py
+++ b/test/TestGetEMRData.py
@@ -43,7 +43,7 @@ class TestGetEMRData(unittest.TestCase):
 
 
     @patch.multiple(pysftp, Connection=_noop)
-    @patch.multiple(GetEmrData, download_file=_noop)
+    @patch.multiple(GetEmrData, download_files=_noop)
     def test_get_emr_data(self):
         """
         This test verifies only that the csv file on the sftp server
@@ -64,7 +64,7 @@ class TestGetEMRData(unittest.TestCase):
 
         props = EmrFileAccessDetails(
             emr_sftp_project_name='/',
-            emr_download_file='raw.csv',
+            emr_download_list='raw.csv',
             emr_host='localhost',
             emr_username='admin',
             emr_password='admin',
@@ -204,7 +204,7 @@ def get_connection_info(private_key):
     """Return a dictionary of parameters for creating a sftp connection"""
     access_details = EmrFileAccessDetails(
         emr_sftp_project_name='/',
-        emr_download_file='raw.csv',
+        emr_download_list='raw.csv',
         emr_host='localhost',
         emr_username='admin',
         emr_password='admin',
@@ -216,7 +216,7 @@ def get_connection_info(private_key):
     connection_info = dict(access_details.__dict__)
     # delete unnecessary elements form the dictionary
     del connection_info['sftp_project_name']
-    del connection_info['download_file']
+    del connection_info['download_list']
     return connection_info
 
 

--- a/test/TestGetEMRData.py
+++ b/test/TestGetEMRData.py
@@ -63,6 +63,7 @@ class TestGetEMRData(unittest.TestCase):
             f.write(input_string)
 
         props = EmrFileAccessDetails(
+            emr_sftp_project_name='/',
             emr_download_file='raw.csv',
             emr_host='localhost',
             emr_username='admin',
@@ -202,6 +203,7 @@ def create_sample_file(sample_file):
 def get_connection_info(private_key):
     """Return a dictionary of parameters for creating a sftp connection"""
     access_details = EmrFileAccessDetails(
+        emr_sftp_project_name='/',
         emr_download_file='raw.csv',
         emr_host='localhost',
         emr_username='admin',
@@ -212,7 +214,8 @@ def get_connection_info(private_key):
     )
 
     connection_info = dict(access_details.__dict__)
-    # delete unnecessary element form the dictionary
+    # delete unnecessary elements form the dictionary
+    del connection_info['sftp_project_name']
     del connection_info['download_file']
     return connection_info
 


### PR DESCRIPTION
This group of commits allows multiple files to be downloaded from the SFTP/EMR server in the GetEmrData module. The user specifies either a single file (the default behavior) which writes to raw.txt automatically on the local disk, or a dictionary with pairs of remote and local files names.