### PR TITLE
Runs the dictionary of preprocessors in order sorted by their keys (m…

### DIFF
--- a/redi/redi.py
+++ b/redi/redi.py
@@ -1995,7 +1995,7 @@ def load_preproc(preprocessors, root='./'):
 
     loaded = {}
 
-    for (preprocessor, path) in ast.literal_eval(preprocessors).iteritems():
+    for (preprocessor, path) in ast.literal_eval(preprocessors.sorted()).iteritems():
         module = None
         if os.path.exists(path):
             module = imp.load_source(preprocessor, path)


### PR DESCRIPTION
…odule names). This is necessary when using multiple preprocessors that have ordered rules. Unsorted dictionaries have unpredictable ordering.