### PR TITLE
Add log file rotation to REDI. 

### DIFF
--- a/docs/redi_usage.rst
+++ b/docs/redi_usage.rst
@@ -1,4 +1,4 @@
-RED-I Usage
+	RED-I Usage
 ===========
 
 Currently the RED-I application can be only executed from the command
@@ -116,7 +116,7 @@ Optional command-line arguments:
 
    The data directory is the directory that will store the following:
 
-   -  log file
+   -  log file. Currently up to 31 days of logs are stored, after which the file begins rotating. 
    -  SQLite database used for storing checksums
    -  intermediate output files which are required for debugging and
       used by the resume logic

--- a/docs/redi_usage.rst
+++ b/docs/redi_usage.rst
@@ -1,4 +1,4 @@
-	RED-I Usage
+RED-I Usage
 ===========
 
 Currently the RED-I application can be only executed from the command

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -61,6 +61,7 @@ __status__ = "Development"
 import ast
 import errno
 import logging
+from logging.handlers import TimedRotatingFileHandler
 import math
 import pickle
 import time
@@ -161,7 +162,8 @@ def main():
         sys.exit()
 
     # configure logger
-    logger = configure_logging(data_directory, args['--verbose'])
+    #TODO: make parameters configurable
+    logger = configure_logging(data_directory, args['--verbose'], when='D', interval=1, backup_count=31)
 
     # Parsing the config file using a method from module SimpleConfigParser
     settings = SimpleConfigParser.SimpleConfigParser()
@@ -1350,7 +1352,7 @@ def research_id_to_redcap_id_converter(
     return bad_ids
 
 
-def configure_logging(data_folder, verbose=False):
+def configure_logging(data_folder, verbose=False, when='D', interval=1, backup_count=31):
     """Configures the Logger"""
 
     # create logger for our application
@@ -1379,7 +1381,7 @@ def configure_logging(data_folder, verbose=False):
     # create a file handler
     file_handler = None
     try:
-        file_handler = logging.FileHandler(filename)
+        file_handler = TimedRotatingFileHandler(filename, when, interval, backup_count)
     except IOError:
         logger.exception('Could not open file for logging "%s"', filename)
         raise


### PR DESCRIPTION
TODO: Make configurable in next release. 

Method used for rotation is same as on GSMI, which also needs to be made configurable.