### PR TITLE
Adding validation for formEvents.xml

### DIFF
--- a/redi/redi.py
+++ b/redi/redi.py
@@ -702,6 +702,8 @@ def parse_form_events(form_events_file):
         logger.info("Form events file contains {} lines." \
                 .format(str(sum(1 for line in raw))))
 
+    validate_xml_file_and_extract_data(form_events_file, pkg_resources.resource_filename(
+        'redi', 'utils/formEvents.xsd'))
     data = etree.parse(form_events_file)
     event_sum = len(data.findall(".//event"))
     logger.debug(str(event_sum) + " total events read into tree.")

--- a/redi/utils/formEvents.xsd
+++ b/redi/utils/formEvents.xsd
@@ -1,0 +1,33 @@
+<?xml version ="1.0"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element name="redcapProject">
+		<xs:complexType>
+		  <xs:sequence>
+				<xs:element name="name" type="xs:string" />
+				<xs:element name="form" maxOccurs="unbounded">
+					<xs:complexType>
+					  <xs:sequence>
+					    <xs:element name="name" type="xs:string"/>
+					    <xs:element name="formDateField" type="xs:string"/>
+							<xs:element name="formFieldDetected" type="xs:string" minOccurs="0"/>
+							<xs:element name="formQuantifiedField" type="xs:string" minOccurs="0"/>
+					    <xs:element name="formCompletedFieldName" type="xs:string"/>
+					    <xs:element name="formCompletedFieldValue" type="xs:int"/>
+					    <xs:element name="formImportedFieldName"  type="xs:string" minOccurs="0"/>
+							<xs:element name="formImportedFieldValue"  type="xs:string" minOccurs="0"/>
+
+							<xs:element name="event" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+												<xs:element name="name" type="xs:string"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/redi/utils/formEvents.xsd
+++ b/redi/utils/formEvents.xsd
@@ -1,31 +1,31 @@
 <?xml version ="1.0"?>
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-	<xs:element name="redcapProject">
-		<xs:complexType>
-		  <xs:sequence>
-				<xs:element name="name" type="xs:string" />
+    <xs:element name="redcapProject">
+	    <xs:complexType>
+		     <xs:sequence>
+			    <xs:element name="name" type="xs:string" />
 				<xs:element name="form" maxOccurs="unbounded">
-					<xs:complexType>
-					  <xs:sequence>
-					    <xs:element name="name" type="xs:string"/>
-					    <xs:element name="formDateField" type="xs:string"/>
-							<xs:element name="formFieldDetected" type="xs:string" minOccurs="0"/>
-							<xs:element name="formQuantifiedField" type="xs:string" minOccurs="0"/>
-					    <xs:element name="formCompletedFieldName" type="xs:string"/>
-					    <xs:element name="formCompletedFieldValue" type="xs:int"/>
-					    <xs:element name="formImportedFieldName"  type="xs:string" minOccurs="0"/>
-							<xs:element name="formImportedFieldValue"  type="xs:string" minOccurs="0"/>
-
-							<xs:element name="event" maxOccurs="unbounded">
-							<xs:complexType>
-								<xs:sequence>
-												<xs:element name="name" type="xs:string"/>
-								</xs:sequence>
-							</xs:complexType>
-						</xs:element>
-
-						</xs:sequence>
-					</xs:complexType>
+				    <xs:complexType>
+					    <xs:sequence>
+                            <xs:element name="name" type="xs:string"/>
+                            <xs:element name="formDateField" type="xs:string"/>
+    					    <xs:element name="formFieldDetected" type="xs:string" minOccurs="0"/>
+						    <xs:element name="formQuantifiedField" type="xs:string" minOccurs="0"/>
+					        <xs:element name="formCompletedFieldName" type="xs:string"/>
+					        <xs:element name="formCompletedFieldValue" type="xs:int"/>
+					        <xs:element name="formImportedFieldName"  type="xs:string" minOccurs="0"/>
+						    <xs:element name="formImportedFieldValue"  type="xs:string" minOccurs="0"/>
+						    <xs:element name="formFieldNotes" type="xs:string" minOccurs="0"/>
+						    <xs:element name="formFieldVerbatim" type="xs:string" minOccurs="0"/>
+						    <xs:element name="event" maxOccurs="unbounded">
+						        <xs:complexType>
+			    			        <xs:sequence>
+				    			        <xs:element name="name" type="xs:string"/>
+					        	    </xs:sequence>
+					            </xs:complexType>
+		    	            </xs:element>
+					    </xs:sequence>
+				    </xs:complexType>
 				</xs:element>
 			</xs:sequence>
 		</xs:complexType>

--- a/test/TestParseAll.py
+++ b/test/TestParseAll.py
@@ -45,8 +45,8 @@ class TestParseAll(unittest.TestCase):
 		<name>cbc</name>
 		<formDateField>cbc_lbdtc</formDateField>
 		<formCompletedFieldName>cbc_complete</formCompletedFieldName>
-		<formImportedFieldName>cbc_nximport</formImportedFieldName>
         <formCompletedFieldValue>2</formCompletedFieldValue>
+		<formImportedFieldName>cbc_nximport</formImportedFieldName>
         <formImportedFieldValue>Y</formImportedFieldValue>
 		<event>
     		<name>1_arm_1</name>
@@ -62,8 +62,8 @@ class TestParseAll(unittest.TestCase):
 		<name>chemistry</name>
 		<formDateField>chem_lbdtc</formDateField>
 		<formCompletedFieldName>chemistry_complete</formCompletedFieldName>
-		<formImportedFieldName>chem_nximport</formImportedFieldName>
         <formCompletedFieldValue>2</formCompletedFieldValue>
+		<formImportedFieldName>chem_nximport</formImportedFieldName>
         <formImportedFieldValue>Y</formImportedFieldValue>
 		<event>
 		    <name>1_arm_1</name>


### PR DESCRIPTION
New utils/formEvents.xsd file validates the formEvents file to prevent errors. Some external site configuration repositories may need XML statements re-ordered to pass validation. RED-I gives an XMLSyntaxError and exits if validation does not pass.