### PR TITLE
Add new keep_all_results behavior to update event tree properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cover/
 coverage.xml
 nosetests.xml
 *.eggs
+*.egg
 venv/
 *.pyc
 *.pyo

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -2101,12 +2101,12 @@ def run_preproc(preprocessors, settings):
             module.run_processing(settings, redi=sys.modules[__name__],
                                   logger=logging)
         except Exception as e:
-            message_format = 'Error processing rule "{0}". {1}'
+            message_format = 'Error processing rule "{0}". {1} {2}'
             if not hasattr(e, 'errors'):
-                errors.append(message_format.format(preprocessor, e.message))
+                errors.append(message_format.format(preprocessor, e.message, e.args))
                 continue
             for error in e.errors:
-                errors.append(message_format.format(preprocessor, error))
+                errors.append(message_format.format(preprocessor, error, e.args))
 
     return errors
 

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -640,7 +640,7 @@ def _create_person_form_event_tree_with_data(
     write_element_tree_to_file(data, os.path.join(data_folder, \
         'rawDataSortedAfterCompression.xml'))
     # update eventName element
-    alert_summary = update_event_name(data, form_events_tree, 'undefined', )
+    alert_summary = update_event_name(data, form_events_tree, 'undefined')
     # write back the changed global Element Tree
     write_element_tree_to_file(data, os.path.join(data_folder, \
         'rawDataWithAllUpdates.xml'))
@@ -1274,8 +1274,8 @@ def update_event_name(data, lookup_data, undefined):
             current_record_group = string.join([study_id, form_name], "_")
             current_timestamp_group = \
                 string.join([study_id, form_name, timestamp], "_")
-        if keep_all_results:
-            logger.info("event_index: {}".format(str(event_index)))
+        # if keep_all_results:
+        #     logger.info("event_index: {}".format(str(event_index)))
 
             if last_record_group != current_record_group:
                 # Check that the event counter form the previous loop did not
@@ -1313,8 +1313,8 @@ def update_event_name(data, lookup_data, undefined):
                 # move to the next event
                 logger.debug("update_event_name: Move to next event: " +
                              current_timestamp_group)
-                if not first_time:
-                    event_index += 1
+                #if not first_time:
+                event_index += 1
                 last_timestamp_group = current_timestamp_group
             else:
                 # this handles the condition where there are two medications on the same day that look identical

--- a/redi/redi.py
+++ b/redi/redi.py
@@ -148,8 +148,15 @@ def main():
     # obtaining command line arguments for path to configuration directory
     args = docopt(__doc__, help=True)
 
+
+    #def get_args():
+    #    return args
+
     # capture any cli args passed in that are needed to pass into other funcs.
     data_directory = args['--datadir']
+    # we need to access this in nested functions.
+    # make it global. CPB made me do it.
+    global keep_all_results
     keep_all_results = args['--keep-all']
 
     if data_directory is None:
@@ -376,6 +383,17 @@ def _run(config_file, configuration_directory, do_keep_gen_files, dry_run,
             settings.emr_sftp_server_private_key_pass,
             )
         GetEmrData.get_emr_data(configuration_directory, connection_details)
+
+    # save raw file into expected location, config directory + "raw.txt"
+    # this is so the prefilters know where to find it
+    if keep_all_results:
+        with open(raw_txt_file, 'r') as f:
+            lines = f.readlines()
+            with open(os.path.join(configuration_directory, "raw.txt"), "w") as f2:
+                f2.writelines(lines)
+        # now that we've written to raw.txt, change raw_txt_file to point to it
+        raw_txt_file = os.path.join(configuration_directory, 'raw.txt')
+
     # load custom pre-processing filters
     pre_filters = load_preproc(settings.preprocessors, configuration_directory)
     # load custom post-processing rules
@@ -622,7 +640,7 @@ def _create_person_form_event_tree_with_data(
     write_element_tree_to_file(data, os.path.join(data_folder, \
         'rawDataSortedAfterCompression.xml'))
     # update eventName element
-    alert_summary = update_event_name(data, form_events_tree, 'undefined')
+    alert_summary = update_event_name(data, form_events_tree, 'undefined', )
     # write back the changed global Element Tree
     write_element_tree_to_file(data, os.path.join(data_folder, \
         'rawDataWithAllUpdates.xml'))
@@ -1219,6 +1237,7 @@ def update_event_name(data, lookup_data, undefined):
     last_record_group = 'dummy'
     last_timestamp_group = 'dummy'
     event_index = 0
+    first_time = True
     lookup_table_length = 1
     old_form_name = 'dummy'
     distinct_value = Counter()
@@ -1242,6 +1261,7 @@ def update_event_name(data, lookup_data, undefined):
         # if the form_name 'undefined, go to the next record!
         if form_name == 'undefined':
             # log something as info
+            logger.info("form_name is marked as undefined.")
             element_to_set.text = undefined
         elif timestamp == '':
             # Log this as bad data we are skipping
@@ -1254,6 +1274,9 @@ def update_event_name(data, lookup_data, undefined):
             current_record_group = string.join([study_id, form_name], "_")
             current_timestamp_group = \
                 string.join([study_id, form_name, timestamp], "_")
+        if keep_all_results:
+            logger.info("event_index: {}".format(str(event_index)))
+
             if last_record_group != current_record_group:
                 # Check that the event counter form the previous loop did not
                 # exceed the size of the event list.  If it did we should
@@ -1281,14 +1304,28 @@ def update_event_name(data, lookup_data, undefined):
                 last_form_name = form_name
                 last_timestamp_group = current_timestamp_group
                 event_index = 0
+                # reset first_time if we're keeping all results
+                # so we don't increment event_index on the first time through
+                if keep_all_results:
+                    first_time = True
+
             if last_timestamp_group != current_timestamp_group:
                 # move to the next event
                 logger.debug("update_event_name: Move to next event: " +
                              current_timestamp_group)
-                event_index += 1
+                if not first_time:
+                    event_index += 1
                 last_timestamp_group = current_timestamp_group
             else:
-                pass
+                # this handles the condition where there are two medications on the same day that look identical
+                # the timestamp group doesn't change in that case, so we much increment it here.
+                if (last_timestamp_group == current_timestamp_group) and keep_all_results:
+                    if first_time:
+                        #logger.info("where event_index: {}".format(event_index))
+                        first_time = False
+                    elif not first_time:
+                        event_index +=1
+
             # note which form we were on
             old_form_name = form_name
             # check that we have not exceeded the event count for this form.

--- a/test/TestSuite.py
+++ b/test/TestSuite.py
@@ -41,6 +41,7 @@ from TestUpdateDataFromLookup import TestUpdateDataFromLookup
 from TestAddElementsToTree import TestAddElementsToTree
 from TestUpdateRedcapFieldNameValueAndUnits import TestUpdateRedcapFieldNameValueAndUnits
 from TestUpdateEventName import TestUpdateEventName
+from TestUpdateEventName_KeepAllEvents import TestUpdateEventName_KeepAllEvents
 from TestResearchIdToRedcapId import TestResearchIdToRedcapId
 from TestUpdateFormImported import TestUpdateFormImported
 from TestCreateSummaryReport import TestCreateSummaryReport
@@ -83,6 +84,7 @@ class redi_suite(unittest.TestSuite):
         redi_test_suite.addTest(TestAddElementsToTree)
         redi_test_suite.addTest(TestUpdateRedcapFieldNameValueAndUnits)
         redi_test_suite.addTest(TestUpdateEventName)
+        redi_test_suite.addTest(TestUpdateEventName_KeepAllEvents)
         redi_test_suite.addTest(TestResearchIdToRedcapId)
         redi_test_suite.addTest(TestUpdateFormImported)
         redi_test_suite.addTest(TestCreateSummaryReport)

--- a/test/TestUpdateEventName.py
+++ b/test/TestUpdateEventName.py
@@ -16,6 +16,7 @@
 # For full text of the BSD 3-Clause License see http://opensource.org/licenses/BSD-3-Clause
 
 import unittest
+import mock
 from lxml import etree
 import os
 from redi import redi
@@ -29,6 +30,7 @@ DEFAULT_DATA_DIRECTORY = os.getcwd()
 class TestUpdateEventName(unittest.TestCase):
 
     def setUp(self):
+        redi.keep_all_results = False
         self.sortedData = """
     <study>
     <subject>

--- a/test/TestUpdateEventName_KeepAllEvents.py
+++ b/test/TestUpdateEventName_KeepAllEvents.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+
+# Contributors:
+# Christopher P. Barnes <senrabc@gmail.com>
+# Andrei Sura: github.com/indera
+# Mohan Das Katragadda <mohan.das142@gmail.com>
+# Philip Chase <philipbchase@gmail.com>
+# Ruchi Vivek Desai <ruchivdesai@gmail.com>
+# Taeber Rapczak <taeber@ufl.edu>
+# Nicholas Rejack <nrejack@ufl.edu>
+# Josh Hanna <josh@hanna.io>
+# Copyright (c) 2014-2015, University of Florida
+# All rights reserved.
+#
+# Distributed under the BSD 3-Clause License
+# For full text of the BSD 3-Clause License see http://opensource.org/licenses/BSD-3-Clause
+
+import unittest
+import mock
+from lxml import etree
+import os
+from redi import redi
+
+file_dir = os.path.dirname(os.path.realpath(__file__))
+goal_dir = os.path.join(file_dir, "../")
+proj_root = os.path.abspath(goal_dir)+'/'
+
+DEFAULT_DATA_DIRECTORY = os.getcwd()
+
+class TestUpdateEventName_KeepAllEvents(unittest.TestCase):
+
+    def setUp(self):
+        redi.keep_all_results = True
+        self.sortedData = """
+    <study>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>07/29/17</Collection_Date>
+        <Collection_Time>11:00</Collection_Time>
+        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
+        <loinc_code>1577876</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>8.7</Result_Value>
+    <timestamp>1906-03-15 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>07/29/17</Collection_Date>
+        <Collection_Time>11:00</Collection_Time>
+        <Component_Name>HEMOGLOBIN</Component_Name>
+        <loinc_code>1534435</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>11.3</Result_Value>
+    <timestamp>1906-03-15 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>12:00</Collection_Time>
+        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
+        <loinc_code>1577876</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>8.7</Result_Value>
+    <timestamp>1903-04-16 12:00</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>12:00</Collection_Time>
+        <Component_Name>HEMOGLOBIN</Component_Name>
+        <loinc_code>1534435</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>11.3</Result_Value>
+    <timestamp>1903-04-16 12:00</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+        <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>10/12/18</Collection_Date>
+        <Collection_Time>12:38</Collection_Time>
+        <Component_Name>BILIRUBIN DIRECT</Component_Name>
+        <loinc_code>1558221</loinc_code>
+        <Reference_Unit>mg/dL</Reference_Unit>
+        <Result_Value>0.8</Result_Value>
+    <timestamp>1908-07-01 12:38</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+        <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>10/12/18</Collection_Date>
+        <Collection_Time>16:01</Collection_Time>
+        <Component_Name>BILIRUBIN DIRECT</Component_Name>
+        <loinc_code>1558221</loinc_code>
+        <Reference_Unit>mg/dL</Reference_Unit>
+        <Result_Value>0.9</Result_Value>
+    <timestamp>1908-07-01 16:01</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>13:50</Collection_Time>
+        <Component_Name>HEMATOCRIT</Component_Name>
+        <loinc_code>1534436</loinc_code>
+        <Reference_Unit>%</Reference_Unit>
+        <Result_Value>34.5</Result_Value>
+    <timestamp>1903-04-16 13:50</timestamp><redcapFormName>undefined</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>07/29/17</Collection_Date>
+        <Collection_Time>11:00</Collection_Time>
+        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
+        <loinc_code>1577876</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>8.7</Result_Value>
+    <timestamp>1906-03-15 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>13:50</Collection_Time>
+        <Component_Name>HEMOGLOBIN</Component_Name>
+        <loinc_code>1534435</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>11.3</Result_Value>
+    <timestamp>1903-04-16 13:50</timestamp><redcapFormName>cbc</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>10/12/18</Collection_Date>
+        <Collection_Time>12:38</Collection_Time>
+        <Component_Name>BILIRUBIN DIRECT</Component_Name>
+        <loinc_code>1558221</loinc_code>
+        <Reference_Unit>mg/dL</Reference_Unit>
+        <Result_Value>0.8</Result_Value>
+    <timestamp>1908-07-01 12:38</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>10/12/18</Collection_Date>
+        <Collection_Time>16:01</Collection_Time>
+        <Component_Name>BILIRUBIN DIRECT</Component_Name>
+        <loinc_code>1558221</loinc_code>
+        <Reference_Unit>mg/dL</Reference_Unit>
+        <Result_Value>0.9</Result_Value>
+    <timestamp>1908-07-01 16:01</timestamp><redcapFormName>chemistry</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>13:50</Collection_Time>
+        <Component_Name>HEMATOCRIT</Component_Name>
+        <loinc_code>1534436</loinc_code>
+        <Reference_Unit>%</Reference_Unit>
+        <Result_Value>34.5</Result_Value>
+    <timestamp>1903-04-16 13:50</timestamp><redcapFormName>undefined</redcapFormName><eventName/><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    </study>"""
+
+        self.data = etree.ElementTree(etree.fromstring(self.sortedData))
+
+        self.form_events = """<?xml version='1.0' encoding='US-ASCII'?>
+<redcapProject>
+	<name>My Test Project</name>
+	<form>
+		<name>cbc</name>
+		<formDateField>cbc_lbdtc</formDateField>
+		<formCompletedFieldName>cbc_complete</formCompletedFieldName>
+		<event>
+			<name>1_arm_1</name>
+		</event>
+		<event>
+			<name>2_arm_1</name>
+		</event>
+		<event>
+			<name>3_arm_1</name>
+		</event>
+		<event>
+			<name>4_arm_1</name>
+		</event>
+    </form>
+	<form>
+		<name>chemistry</name>
+		<formDateField>chemistry_lbdtc</formDateField>
+		<formCompletedFieldName>chemistry_complete</formCompletedFieldName>
+		<event>
+			<name>1_arm_1</name>
+		</event>
+		<event>
+			<name>2_arm_1</name>
+		</event>
+		<event>
+			<name>3_arm_1</name>
+		</event>
+		<event>
+			<name>4_arm_1</name>
+		</event>
+    </form>
+</redcapProject>
+"""
+
+        self.form_events_tree = etree.ElementTree(etree.fromstring(self.form_events))
+
+        self.output = """<study>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>07/29/17</Collection_Date>
+        <Collection_Time>11:00</Collection_Time>
+        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
+        <loinc_code>1577876</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>8.7</Result_Value>
+    <timestamp>1906-03-15 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName>1_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>07/29/17</Collection_Date>
+        <Collection_Time>11:00</Collection_Time>
+        <Component_Name>HEMOGLOBIN</Component_Name>
+        <loinc_code>1534435</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>11.3</Result_Value>
+    <timestamp>1906-03-15 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName>2_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>12:00</Collection_Time>
+        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
+        <loinc_code>1577876</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>8.7</Result_Value>
+    <timestamp>1903-04-16 12:00</timestamp><redcapFormName>cbc</redcapFormName><eventName>3_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>12:00</Collection_Time>
+        <Component_Name>HEMOGLOBIN</Component_Name>
+        <loinc_code>1534435</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>11.3</Result_Value>
+    <timestamp>1903-04-16 12:00</timestamp><redcapFormName>cbc</redcapFormName><eventName>4_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+        <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>10/12/18</Collection_Date>
+        <Collection_Time>12:38</Collection_Time>
+        <Component_Name>BILIRUBIN DIRECT</Component_Name>
+        <loinc_code>1558221</loinc_code>
+        <Reference_Unit>mg/dL</Reference_Unit>
+        <Result_Value>0.8</Result_Value>
+    <timestamp>1908-07-01 12:38</timestamp><redcapFormName>chemistry</redcapFormName><eventName>1_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+        <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>10/12/18</Collection_Date>
+        <Collection_Time>16:01</Collection_Time>
+        <Component_Name>BILIRUBIN DIRECT</Component_Name>
+        <loinc_code>1558221</loinc_code>
+        <Reference_Unit>mg/dL</Reference_Unit>
+        <Result_Value>0.9</Result_Value>
+    <timestamp>1908-07-01 16:01</timestamp><redcapFormName>chemistry</redcapFormName><eventName>2_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>11</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>13:50</Collection_Time>
+        <Component_Name>HEMATOCRIT</Component_Name>
+        <loinc_code>1534436</loinc_code>
+        <Reference_Unit>%</Reference_Unit>
+        <Result_Value>34.5</Result_Value>
+    <timestamp>1903-04-16 13:50</timestamp><redcapFormName>undefined</redcapFormName><eventName>undefined</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>07/29/17</Collection_Date>
+        <Collection_Time>11:00</Collection_Time>
+        <Component_Name>WHITE BLOOD CELL COUNT</Component_Name>
+        <loinc_code>1577876</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>8.7</Result_Value>
+    <timestamp>1906-03-15 11:00</timestamp><redcapFormName>cbc</redcapFormName><eventName>1_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>13:50</Collection_Time>
+        <Component_Name>HEMOGLOBIN</Component_Name>
+        <loinc_code>1534435</loinc_code>
+        <Reference_Unit>g/dL</Reference_Unit>
+        <Result_Value>11.3</Result_Value>
+    <timestamp>1903-04-16 13:50</timestamp><redcapFormName>cbc</redcapFormName><eventName>2_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>10/12/18</Collection_Date>
+        <Collection_Time>12:38</Collection_Time>
+        <Component_Name>BILIRUBIN DIRECT</Component_Name>
+        <loinc_code>1558221</loinc_code>
+        <Reference_Unit>mg/dL</Reference_Unit>
+        <Result_Value>0.8</Result_Value>
+    <timestamp>1908-07-01 12:38</timestamp><redcapFormName>chemistry</redcapFormName><eventName>1_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>10/12/18</Collection_Date>
+        <Collection_Time>16:01</Collection_Time>
+        <Component_Name>BILIRUBIN DIRECT</Component_Name>
+        <loinc_code>1558221</loinc_code>
+        <Reference_Unit>mg/dL</Reference_Unit>
+        <Result_Value>0.9</Result_Value>
+    <timestamp>1908-07-01 16:01</timestamp><redcapFormName>chemistry</redcapFormName><eventName>2_arm_1</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    <subject>
+        <STUDY_ID>22</STUDY_ID>
+        <Collection_Date>05/20/20</Collection_Date>
+        <Collection_Time>13:50</Collection_Time>
+        <Component_Name>HEMATOCRIT</Component_Name>
+        <loinc_code>1534436</loinc_code>
+        <Reference_Unit>%</Reference_Unit>
+        <Result_Value>34.5</Result_Value>
+    <timestamp>1903-04-16 13:50</timestamp><redcapFormName>undefined</redcapFormName><eventName>undefined</eventName><formDateField/><formCompletedFieldName/><timestamp/><redcapFormName/><eventName/><formDateField/><formCompletedFieldName/></subject>
+    </study>"""
+
+        self.expect = etree.tostring(etree.fromstring(self.output))
+
+    def test_update_event_name_keep_all_events(self):
+        redi.configure_logging(DEFAULT_DATA_DIRECTORY)
+        redi.update_event_name(self.data, self.form_events_tree, 'undefined')
+        result = etree.tostring(self.data)
+        self.assertEqual(self.expect, result)
+
+    def tearDown(self):
+        return()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
These updates improve the behavior when keep_all_events is True. The event tree is now numbers the REDCap events in proper numeric sequence. In addition, there is a new test to test this behavior in update_event_name. Also, when using the -f switch with preprocessors the input file is rewritten to 'raw.txt' to ensure preprocessors can see the file.