### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ RED-I Project
 
 <a href="https://zenodo.org/badge/latestdoi/4064/ctsit/redi"><img src="https://zenodo.org/badge/4064/ctsit/redi.svg" alt="10.5281/zenodo.47793"><a>
 [![Travis CI](https://api.travis-ci.org/ctsit/redi.svg?branch=master)](https://api.travis-ci.org/ctsit/redi.svg?branch=master)
-[![Version](https://pypip.in/v/redi/badge.png)](https://pypip.in/v/redi/badge.png)
+[![Version](https://img.shields.io/pypi/v/redi.svg)](https://img.shields.io/pypi/v/redi.svg)
 [![Coverage Status Master](https://coveralls.io/repos/ctsit/redi/badge.svg?branch=master)](https://coveralls.io/r/ctsit/redi?branch=master)
 [![Coverage Status Develop](https://coveralls.io/repos/ctsit/redi/badge.svg?branch=develop)](https://coveralls.io/r/ctsit/redi?branch=develop)
-[![Downloads](https://pypip.in/d/redi/badge.png)](https://pypip.in/d/redi/badge.png)
+[![Downloads](https://img.shields.io/pypi/dm/redi.svg)](https://img.shields.io/pypi/dm/redi.svg)
 
 
 Introduction


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20redi))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `redi`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.